### PR TITLE
Fixed a bug with Entra app creation

### DIFF
--- a/infra/app/apim-oauth/entra-app.bicep
+++ b/infra/app/apim-oauth/entra-app.bicep
@@ -1,10 +1,10 @@
 extension microsoftGraphV1
 
 @description('The name of the Entra application')
-param entraAppName string = 'mcp-oauth-app'
+param entraAppUniqueName string
 
 @description('The display name of the Entra application')
-param entraAppDisplayName string = 'MCP OAuth App'
+param entraAppDisplayName string
 
 @description('Tenant ID where the application is registered')
 param tenantId string = tenant().tenantId
@@ -20,7 +20,7 @@ var issuer = '${loginEndpoint}${tenantId}/v2.0'
 
 resource entraApp 'Microsoft.Graph/applications@v1.0' = {
   displayName: entraAppDisplayName
-  uniqueName: entraAppName
+  uniqueName: entraAppUniqueName
   web: {
     redirectUris: [
       apimOauthCallback

--- a/infra/app/apim-oauth/oauth.bicep
+++ b/infra/app/apim-oauth/oauth.bicep
@@ -14,6 +14,12 @@ param entraAppUserAssignedIdentityPrincipleId string
 @description('The client ID of the user-assigned managed identity for Entra app')
 param entraAppUserAssignedIdentityClientId string
 
+@description('The name of the Entra application')
+param entraAppUniqueName string
+
+@description('The display name of the Entra application')
+param entraAppDisplayName string
+
 resource apimService 'Microsoft.ApiManagement/service@2021-08-01' existing = {
   name: apimServiceName
 }
@@ -21,6 +27,8 @@ resource apimService 'Microsoft.ApiManagement/service@2021-08-01' existing = {
 module entraApp './entra-app.bicep' = {
   name: 'entraApp'
   params:{
+    entraAppUniqueName: entraAppUniqueName
+    entraAppDisplayName: entraAppDisplayName
     apimOauthCallback: '${apimService.properties.gatewayUrl}/oauth-callback'
     userAssignedIdentityPrincipleId: entraAppUserAssignedIdentityPrincipleId
   }


### PR DESCRIPTION
## Purpose
Fixed a bug with entra app creation.

The issue was when you run the command `azd up`, how it works is, is it tries to create or update the resources, but since the appname was hardcoded, so if an app already exists, and the `azd up` command tries to update that, and it fails, due to insufficient permission. For modifying resources, you need to have permission, and obviously none of us will have permission to modify the app that was created by another user.

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```