### PR TITLE
Enables vnet by default if no env var is set

### DIFF
--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -9,7 +9,7 @@
       "value": "${AZURE_LOCATION}"
     },
     "vnetEnabled": {
-      "value": "${VNET_ENABLED}"
+      "value": "${VNET_ENABLED=true}"
     },
     "apimSku": {
       "value": "Basicv2" 


### PR DESCRIPTION
Enables vnet by default if no env var is set

This is important if policies require network isolation.  

Test with `azd up` and it will set vnet to true.  

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
